### PR TITLE
Attempt to fix ACRAPI config broken in last commit

### DIFF
--- a/app/ACRAPI.py
+++ b/app/ACRAPI.py
@@ -45,12 +45,11 @@ class ACRAPI():
 
 
     def noisy(filePath):
-        config = config_noisy
 
         '''This module can recognize ACRCloud by most of audio/video file.
             Audio: mp3, wav, m4a, flac, aac, amr, ape, ogg ...
             Video: mp4, mkv, wmv, flv, ts, avi ...'''
-        re = ACRCloudRecognizer(config)
+        re = ACRCloudRecognizer(config['noisy'])
 
         #recognize by file path, and skip 0 seconds from from the beginning of sys.argv[1].
         #re.recognize_by_file(filePath, 0, 10)
@@ -66,12 +65,11 @@ class ACRAPI():
 
 
     def hum(filePath):
-        config = config_hum
 
         '''This module can recognize ACRCloud by most of audio/video file.
             Audio: mp3, wav, m4a, flac, aac, amr, ape, ogg ...
             Video: mp4, mkv, wmv, flv, ts, avi ...'''
-        re = ACRCloudRecognizer(config)
+        re = ACRCloudRecognizer(config['hum'])
 
         #recognize by file path, and skip 0 seconds from from the beginning of sys.argv[1].
         #re.recognize_by_file(filePath, 0, 10)

--- a/app/SongIDCore.py
+++ b/app/SongIDCore.py
@@ -3,7 +3,7 @@ from telegram.ext import Updater, MessageHandler, Filters, CommandHandler, Messa
 import sentry_sdk
 
 
-ver='1.0.0-beta1'
+ver='1.0.0-beta2'
 botName=f'SongID'
 botVer=f'{botName} {ver}'
 botAt=f'@SongIDBot'


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the configuration issue in the ACRAPI module by correctly referencing the 'noisy' and 'hum' keys in the config dictionary.